### PR TITLE
replace pattern input box with textarea and add a quickstart script

### DIFF
--- a/src/main/scala/net/stoerr/grokconstructor/webframework/WebForm.scala
+++ b/src/main/scala/net/stoerr/grokconstructor/webframework/WebForm.scala
@@ -24,12 +24,13 @@ trait WebForm extends TableMaker {
 
     def valueSplitToLines: Array[String] = value.map(_.split("\r?\n")).getOrElse(Array())
 
-    def inputText(label: String, cols: Int, enabled: Boolean = true): Elem =
+    def inputText(label: String, cols: Int, rows: Int = 6, enabled: Boolean = true): Elem =
       <div class="ym-fbox-text">
         <label for={name}>
           {new Text(label)}
-        </label> <input
-        type="text" name={name} id={name} size={cols.toString} value={value.orNull} disabled={if (enabled) null else "disabled"}/>
+        </label>
+          <textarea name={name} id={name} cols={cols.toString} rows={rows.toString}
+                  disabled={if (enabled) null else "disabled"}>{value.orNull} </textarea>
       </div>
 
     def inputTextArea(label: String, rows: Int, cols: Int): Elem =

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+mvn appengine:devserver -Dmaven.test.skip=true


### PR DESCRIPTION
- replace pattern input box with textarea.  
  when grok pattern is long, it's inconvenience to scroll the input box to check the grok pattern.
- add a quickstart script
